### PR TITLE
EDITOR-#13 Markers in Wavesurfer & Edit and Add button turn to Cancel after clicked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10963,9 +10963,9 @@
       }
     },
     "wavesurfer.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-4.2.0.tgz",
-      "integrity": "sha512-g+d1BFAEVvKpILe/oRM/Mle8dX+Vs6y5bEDmiJdCaR15bO/xKuQyN7cGzhYE4jgnkZkAvog4ElL6JLGGUmilyQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-4.6.0.tgz",
+      "integrity": "sha512-+nn6VD86pTtRu9leVNXoIGOCMJyaTNsKNy9v+SfUsYo+SxLCQvEzrZZ/eKMImqspsk+BX1V1xlY4FRkHswu3fA=="
     },
     "wbuf": {
       "version": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-redux": "^7.2.2",
     "react-resizable": "^1.11.0",
     "redux": "^4.0.5",
-    "wavesurfer.js": "^4.2.0",
+    "wavesurfer.js": "^4.6.0",
     "ws": "^7.4.3"
   },
   "scripts": {

--- a/src/client/components/bar/index.js
+++ b/src/client/components/bar/index.js
@@ -5,6 +5,7 @@ import Typography from "@material-ui/core/Typography";
 // components
 import TimeController from "./timeController";
 import Tools from "../tools";
+import MarkerSwitch from "../wavesurfer/markerSwitch";
 
 const useStyles = makeStyles({
   flex: {
@@ -30,6 +31,7 @@ export default function Bar() {
       </Typography>
       <TimeController />
       <Tools />
+      <MarkerSwitch/>
     </div>
   );
 }

--- a/src/client/components/modeSelector/index.js
+++ b/src/client/components/modeSelector/index.js
@@ -46,22 +46,24 @@ export default function ModeSelector({ handleSave, handleDelete }) {
       <Button
         variant="outlined"
         size="small"
-        style={{
-          backgroundColor: mode === EDIT ? "#505050" : "",
-        }}
+        color={ mode === EDIT ? "secondary" : ""}
+        // style={{
+        //   backgroundColor: mode === EDIT ? "#505050" : "",
+        // }}
         onClick={() => handleChangeMode(EDIT)}
       >
-        EDIT
+        { mode === EDIT ? "Cancel" : "EDIT" }
       </Button>
       <Button
         variant="outlined"
         size="small"
-        style={{
-          backgroundColor: mode === ADD ? "#505050" : "",
-        }}
+        color={ mode === ADD ? "secondary" : ""}
+        // style={{
+        //   backgroundColor: mode === ADD ? "#505050" : "",
+        // }}
         onClick={() => handleChangeMode(ADD)}
       >
-        ADD
+        { mode === ADD ? "Cancel" : "ADD" }
       </Button>
       <Button
         variant="outlined"

--- a/src/client/components/modeSelector/index.js
+++ b/src/client/components/modeSelector/index.js
@@ -47,9 +47,6 @@ export default function ModeSelector({ handleSave, handleDelete }) {
         variant="outlined"
         size="small"
         color={ mode === EDIT ? "secondary" : ""}
-        // style={{
-        //   backgroundColor: mode === EDIT ? "#505050" : "",
-        // }}
         onClick={() => handleChangeMode(EDIT)}
       >
         { mode === EDIT ? "Cancel" : "EDIT" }
@@ -58,9 +55,6 @@ export default function ModeSelector({ handleSave, handleDelete }) {
         variant="outlined"
         size="small"
         color={ mode === ADD ? "secondary" : ""}
-        // style={{
-        //   backgroundColor: mode === ADD ? "#505050" : "",
-        // }}
         onClick={() => handleChangeMode(ADD)}
       >
         { mode === ADD ? "Cancel" : "ADD" }

--- a/src/client/components/wavesurfer/index.js
+++ b/src/client/components/wavesurfer/index.js
@@ -25,7 +25,9 @@ import { WaveSurferAppContext } from "../../contexts/wavesurferContext";
  * @component
  */
 const Wavesurfer = () => {
-  const { waveSurferApp, initWaveSurferApp } = useContext(WaveSurferAppContext);
+  const { waveSurferApp, initWaveSurferApp, markersToggle } = useContext(
+    WaveSurferAppContext
+  );
   // const [waveSurferApp, setWaveSurferApp] = useState(null);
   useEffect(() => {
     const newWaveSurferApp = new WaveSurferApp();
@@ -41,9 +43,18 @@ const Wavesurfer = () => {
 
   //update Markers
   useEffect(() => {
-    if (controlRecord && waveSurferApp)
+    if (controlRecord && waveSurferApp && markersToggle)
       waveSurferApp.updateMarkers(controlRecord);
   }, [controlRecord]);
+
+  //update Markers when markers switched on
+  useEffect(() => {
+    if (!controlRecord || !waveSurferApp)return;
+    if (markersToggle)
+      waveSurferApp.updateMarkers(controlRecord);
+    else
+      waveSurferApp.clearMarker();
+  }, [markersToggle]);
 
   // listen to time set by other component
   useEffect(() => {

--- a/src/client/components/wavesurfer/index.js
+++ b/src/client/components/wavesurfer/index.js
@@ -37,6 +37,13 @@ const Wavesurfer = () => {
   const {
     timeData: { from, time },
   } = useSelector(selectGlobal);
+  const { controlRecord } = useSelector(selectGlobal);
+
+  //update Markers
+  useEffect(() => {
+    if (controlRecord && waveSurferApp)
+      waveSurferApp.updateMarkers(controlRecord);
+  }, [controlRecord]);
 
   // listen to time set by other component
   useEffect(() => {

--- a/src/client/components/wavesurfer/markerSwitch.js
+++ b/src/client/components/wavesurfer/markerSwitch.js
@@ -1,0 +1,27 @@
+import React, { useContext } from "react";
+import { WaveSurferAppContext } from "../../contexts/wavesurferContext";
+import { Switch } from "@material-ui/core";
+import { FormControlLabel } from "@material-ui/core";
+
+export default function MarkerSwitch() {
+  const { markersToggle, toggleMarkers } = useContext(WaveSurferAppContext);
+
+  //toggle markers
+  const handleChange = () => {
+    toggleMarkers(!markersToggle);
+  };
+
+  return (
+    <FormControlLabel
+      control={
+        <Switch
+          color="primary"
+          checked={markersToggle}
+          onChange={handleChange}
+        />
+      }
+      label="Markers"
+      labelPlacement="start"
+    />
+  );
+}

--- a/src/client/components/wavesurfer/waveSurferApp.js
+++ b/src/client/components/wavesurfer/waveSurferApp.js
@@ -52,8 +52,8 @@ class WaveSurferApp {
           markers: [
             {
               time: 0,
-              label: "Begin",
-              color: "#ffffff",
+              // label: "Begin",
+              color: "#8AE5C8",
               position: "bottom",
             },
           ],
@@ -203,8 +203,8 @@ class WaveSurferApp {
   addMarkers(start, index) {
     this.waveSurfer.addMarker({
       time: start,
-      color: "#ffffff",
-      label: index ? index : "Begin",
+      color: "#8AE5C8",
+      // label: index ? index : "Begin",
       position: "top",
     });
   }
@@ -218,6 +218,14 @@ class WaveSurferApp {
     controlRecord.map((e, index) => {
       this.addMarkers(e.start / 1000, index);
     });
+  }
+
+  /**
+   * clear all markers
+   * @function
+   */
+  clearMarker() {
+    this.waveSurfer.clearMarkers();
   }
 
   zoom(newValue) {

--- a/src/client/components/wavesurfer/waveSurferApp.js
+++ b/src/client/components/wavesurfer/waveSurferApp.js
@@ -1,6 +1,7 @@
 import WaveSurfer from "wavesurfer.js";
 import CursorPlugin from "wavesurfer.js/dist/plugin/wavesurfer.cursor";
 import regions from "wavesurfer.js/src/plugin/regions";
+import MarkersPlugin from "wavesurfer.js/dist/plugin/wavesurfer.markers";
 
 // redux
 import store from "../../store";
@@ -46,6 +47,16 @@ class WaveSurferApp {
         }),
         regions.create({
           regionsMinLength: 0,
+        }),
+        MarkersPlugin.create({
+          markers: [
+            {
+              time: 0,
+              label: "Begin",
+              color: "#ffffff",
+              position: "bottom",
+            },
+          ],
         }),
       ],
     });
@@ -181,6 +192,22 @@ class WaveSurferApp {
       end: end / 1000,
       loop: false,
       color: "hsla(400, 100%, 30%, 0.5)",
+    });
+  }
+
+  addMarkers(start, index) {
+    this.waveSurfer.addMarker({
+      time: start,
+      color: "#ffffff",
+      label: index ? index : "Begin",
+      position: "top",
+    });
+  }
+
+  updateMarkers(controlRecord) {
+    this.waveSurfer.clearMarkers();
+    controlRecord.map((e, index) => {
+      this.addMarkers(e.start / 1000, index);
     });
   }
 

--- a/src/client/components/wavesurfer/waveSurferApp.js
+++ b/src/client/components/wavesurfer/waveSurferApp.js
@@ -195,6 +195,11 @@ class WaveSurferApp {
     });
   }
 
+  /**
+   * create a new marker
+   * @param { number } time  - time where marker created
+   * @param { number } index - marker's label
+   */
   addMarkers(start, index) {
     this.waveSurfer.addMarker({
       time: start,
@@ -204,6 +209,10 @@ class WaveSurferApp {
     });
   }
 
+  /**
+   * create markers according to all dancer's status
+   * @param { Array<{}> } controlRecord - array of all dancer's status
+   */
   updateMarkers(controlRecord) {
     this.waveSurfer.clearMarkers();
     controlRecord.map((e, index) => {

--- a/src/client/contexts/wavesurferContext.js
+++ b/src/client/contexts/wavesurferContext.js
@@ -5,12 +5,13 @@ export const WaveSurferAppContext = createContext(null);
 
 export default function WaveSurfer({ children }) {
   const [waveSurferApp, setWaveSurferApp] = useState(null);
+  const [markersToggle, toggleMarkers] = useState(true);
   const initWaveSurferApp = (wave) => {
     setWaveSurferApp(wave);
   };
 
   return (
-    <WaveSurferAppContext.Provider value={{ waveSurferApp, initWaveSurferApp }}>
+    <WaveSurferAppContext.Provider value={{ waveSurferApp, markersToggle, initWaveSurferApp, toggleMarkers }}>
       {children}
     </WaveSurferAppContext.Provider>
   );

--- a/src/client/slices/globalSlice.js
+++ b/src/client/slices/globalSlice.js
@@ -577,6 +577,7 @@ export const globalSlice = createSlice({
     toggleMode: (state, action) => {
       if (action.payload === state.mode) {
         state.mode = IDLE;
+        //reset currentStatus when switching mode back to IDLE
         const currentControlFrame = state.timeData.controlFrame;
         if (currentControlFrame === state.controlRecord.length - 1) {
           // Can't fade
@@ -589,6 +590,7 @@ export const globalSlice = createSlice({
             state.controlRecord[currentControlFrame + 1]
           );
         }
+        //reset currentPosFrame when switching mode back to IDLE
         const currentPosFrame = state.timeData.posFrame
         if (currentPosFrame === state.posRecord.length - 1) {
           // can't interpolation

--- a/src/client/slices/globalSlice.js
+++ b/src/client/slices/globalSlice.js
@@ -575,8 +575,33 @@ export const globalSlice = createSlice({
      * @param {number} action.payload - new mode
      */
     toggleMode: (state, action) => {
-      if (action.payload === state.mode) state.mode = IDLE;
-      else state.mode = action.payload;
+      if (action.payload === state.mode) {
+        state.mode = IDLE;
+        const currentControlFrame = state.timeData.controlFrame;
+        if (currentControlFrame === state.controlRecord.length - 1) {
+          // Can't fade
+          state.currentStatus = state.controlRecord[currentControlFrame].status;
+        } else {
+          // do fade
+          state.currentStatus = fadeStatus(
+            state.timeData.time,
+            state.controlRecord[currentControlFrame],
+            state.controlRecord[currentControlFrame + 1]
+          );
+        }
+        const currentPosFrame = state.timeData.posFrame
+        if (currentPosFrame === state.posRecord.length - 1) {
+          // can't interpolation
+          state.currentPos = state.posRecord[currentPosFrame].pos;
+        } else {
+          // do interpolation
+          state.currentPos = interpolationPos(
+            state.timeData.time,
+            state.posRecord[currentPosFrame],
+            state.posRecord[currentPosFrame + 1]
+          );
+        }
+      } else state.mode = action.payload;
     },
 
     /**


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
-->
1. Add markers in wavesurfer to show frames' position.
2. EDIT and ADD buttons would toggle to Cancel. Click Cancel would reset `currentStatus` to origin.

### What type of PR is it?
Feature

### Todos
None

### What is the Github issue?
<a href="https://github.com/NTUEELightDance/LightDance-Editor/issues/13">#13</a>

### How should this be tested?
1. Add frame arbitrary, new markers would be showed in wavesurfer. 
2. click EDIT or ADD buttons, make some changes, and click Cancel button. 

### Screenshots (if appropriate)
<img width="1440" alt="markers cancelbtn" src="https://user-images.githubusercontent.com/73121038/145681628-7f32f52d-96b5-4e2c-8613-489f369ddc9a.png">

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No

