### PR TITLE
EDITOR-#148 There won't be position's interpolation on changing time by controlFrameIndex.

### DIFF
--- a/editor/core/actions/timeData.ts
+++ b/editor/core/actions/timeData.ts
@@ -82,7 +82,6 @@ const actions = registerActions({
    */
   setCurrentControlIndex: async (state: State, payload: number) => {
     const [controlMap, controlRecord] = await getControl();
-    const [posMap, posRecord] = await getPos();
     let controlIndex = payload;
     if (isNaN(controlIndex)) {
       throw new Error(
@@ -90,20 +89,8 @@ const actions = registerActions({
       );
     }
     controlIndex = clamp(controlIndex, 0, controlRecord.length - 1);
-    state.currentControlIndex = controlIndex;
-    state.currentTime = controlMap[controlRecord[controlIndex]].start;
-    state.currentStatus = controlMap[controlRecord[controlIndex]].status;
-    // set posIndex and currentPos as well (by time)
-    const newPosIndex = updateFrameByTimeMap(
-      posRecord,
-      posMap,
-      state.currentPosIndex,
-      controlMap[controlRecord[controlIndex]].start
-    );
-    state.currentPosIndex = newPosIndex;
-    state.currentPos = posMap[posRecord[newPosIndex]].pos;
-    // set currentFade
-    state.currentFade = controlMap[controlRecord[controlIndex]].fade;
+    const newTime = controlMap[controlRecord[controlIndex]].start;
+    setCurrentTime({ payload: newTime });
   },
 
   /**
@@ -112,7 +99,6 @@ const actions = registerActions({
    * @param {object} payload
    */
   setCurrentPosIndex: async (state: State, payload: number) => {
-    const [controlMap, controlRecord] = await getControl();
     const [posMap, posRecord] = await getPos();
     let posIndex = payload;
     if (isNaN(posIndex)) {
@@ -121,20 +107,8 @@ const actions = registerActions({
       );
     }
     posIndex = clamp(posIndex, 0, posRecord.length - 1);
-    state.currentPosIndex = posIndex;
-    state.currentTime = posMap[posRecord[posIndex]].start;
-    state.currentPos = posMap[posRecord[posIndex]].pos;
-    // set controlIndex and currentStatus as well (by time)
-    const newControlIndex = updateFrameByTimeMap(
-      controlRecord,
-      controlMap,
-      state.currentControlIndex,
-      posMap[posRecord[posIndex]].start
-    );
-    state.currentControlIndex = newControlIndex;
-    state.currentStatus = controlMap[controlRecord[newControlIndex]].status;
-    // set currentFade
-    state.currentFade = controlMap[controlRecord[newControlIndex]].fade;
+    const newTime = posMap[posRecord[posIndex]].start;
+    setCurrentTime({ payload: newTime });
   },
 });
 

--- a/editor/core/actions/timeData.ts
+++ b/editor/core/actions/timeData.ts
@@ -14,6 +14,7 @@ import { State } from "../models";
 const actions = registerActions({
   /**
    * calculate the currentStatus, currentPos according to the time
+   * It will do fade or position interpolation
    * @param {State} statue
    * @param {object} payload
    */
@@ -77,6 +78,7 @@ const actions = registerActions({
 
   /**
    * set currentControlIndex by controlIndex, also set currentStatus
+   * call setCurrentTime to calculate new status and pos, including fade and interpolation
    * @param {State} state
    * @param {object} payload
    */
@@ -94,7 +96,8 @@ const actions = registerActions({
   },
 
   /**
-   * set currentPosIndex by posIndex, also set currentPos
+   * set currentPosIndex by posIndex
+   * call setCurrentTime to calculate new status and pos, including fade and interpolation
    * @param {State} state
    * @param {object} payload
    */


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
-->

There won't be position's interpolation on changing time by controlFrameIndex.

Solve:
change `setCurrentControlIndex` and `setCurrentPosIndex` logic.
Make them to call `setCurrentTime` to the new controlIndex's start time or new posIndex's start time

### What type of PR is it?
Bug Fix

### Todos
None

### What is the Github issue?
<!-- * Open an issue on Github
* Put link here, and add [EDITOR-#issue_number] in PR title, eg. `EDITOR-#9. PR title`
-->

Resolve #148 

### How should this be tested?
<!--
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

1. Add some positions and status.
2. Change the controlFrameIndex by right/left, and you can find that the position won't be the interpolation time.

### Screenshots (if appropriate)

None

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
