### PR TITLE
EDITOR-#212. Allow empty string as ledMap input

### DIFF
--- a/editor-server/src/models/LED.ts
+++ b/editor-server/src/models/LED.ts
@@ -8,7 +8,7 @@ const LEDSchema = new Schema({
   },
   effectName: {
     type: String,
-    required: [true, "effectName field is required."],
+    default: "",
   },
   repeat: {
     type: Number,

--- a/editor-server/src/resolvers/inputs/led.ts
+++ b/editor-server/src/resolvers/inputs/led.ts
@@ -5,8 +5,8 @@ export class AddLEDInput {
   @Field((type) => String)
   partName: string;
 
-  @Field((type) => String)
-  effectName: string;
+  @Field((type) => String, {nullable: true})
+  effectName?: string;
 
   @Field((type) => Int)
   repeat: number;
@@ -20,8 +20,8 @@ export class DeleteLEDInput {
   @Field((type) => String)
   partName: string;
 
-  @Field((type) => String)
-  effectName: string;
+  @Field((type) => String, {nullable: true})
+  effectName?: string;
 }
 
 @InputType()

--- a/editor-server/src/resolvers/led.ts
+++ b/editor-server/src/resolvers/led.ts
@@ -24,7 +24,11 @@ export class LEDResolver {
 
   @Mutation((returns) => LEDEffectResponse)
   async addLED(@Arg("input") input: AddLEDInput, @Ctx() ctx: any) {
-    const { partName, effectName, repeat, effects } = input;
+    const { partName, repeat, effects } = input;
+    let {effectName} = input;
+    if (!effectName) {
+      effectName = "";
+    }
 
     // check part validity
     const part = ctx.db.Part.findOne({ name: partName, type: "LED" });
@@ -32,11 +36,11 @@ export class LEDResolver {
       return Object.assign(
         {
           partName,
-          effectName: ",",
+          effectName: "",
           repeat: -1,
           effects: [],
         },
-        { ok: false, msg: "effectName exist." }
+        { ok: false, msg: "part not found." }
       );
     }
 
@@ -52,7 +56,10 @@ export class LEDResolver {
 
   @Mutation((returns) => DeleteLEDEffectResponse)
   async deleteLED(@Arg("input") input: DeleteLEDInput, @Ctx() ctx: any) {
-    const { partName, effectName } = input;
+    let { partName, effectName } = input;
+    if (!effectName) {
+      effectName = "";
+    }
 
     // check exist
     const exist = await ctx.db.LED.findOne({ partName, effectName });

--- a/editor-server/src/resolvers/types/ledEffect.ts
+++ b/editor-server/src/resolvers/types/ledEffect.ts
@@ -5,8 +5,8 @@ export class LEDEffect {
   @Field((type) => String)
   partName: string;
 
-  @Field((type) => String)
-  effectName: string;
+  @Field((type) => String, {nullable: true})
+  effectName?: string;
 
   @Field((type) => Int)
   repeat: number;

--- a/editor-server/src/schema.gql
+++ b/editor-server/src/schema.gql
@@ -13,7 +13,7 @@ input AddDancerInput {
 }
 
 input AddLEDInput {
-  effectName: String!
+  effectName: String
   effects: [LEDEffectInput!]!
   partName: String!
   repeat: Int!
@@ -141,7 +141,7 @@ type DeleteLEDEffectResponse {
 }
 
 input DeleteLEDInput {
-  effectName: String!
+  effectName: String
   partName: String!
 }
 
@@ -247,7 +247,7 @@ input LEDEffectInput {
 }
 
 type LEDEffectResponse {
-  effectName: String!
+  effectName: String
   effects: [LEDEffects!]!
   msg: String
   ok: Boolean!


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
-->
Allow empty string as ledMap input

### What type of PR is it?
[Bug Fix ]

### Todos

### What is the Github issue?
<!-- * Open an issue on Github
* Put link here, and add [EDITOR-#issue_number] in PR title, eg. `EDITOR-#9. PR title`
-->
[EDITOR-#212. Backend: LED effectName with empty string should be valid](https://github.com/NTUEELightDance/LightDance-Editor/issues/212)
### How should this be tested?
<!--
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
Resolve ![image](https://user-images.githubusercontent.com/72752478/157572160-78f75174-4245-4121-8f0a-7e9d03758050.png)


### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
