### PR TITLE
EDITOR-#278 Wrong default value for LED's setting 

### DIFF
--- a/editor/components/ThreeSimulator/Settings/index.ts
+++ b/editor/components/ThreeSimulator/Settings/index.ts
@@ -10,7 +10,7 @@ class Settings {
 
     this.settings = {
       Visibility: {
-        LED: false,
+        LED: true,
         FIBER: true,
         "Grid Helper": true,
         Center: true,


### PR DESCRIPTION
### What is this PR for?
Wrong default value for LED's setting 

### What type of PR is it?
Bug Fix

### Todos
* [x] Change default value for LED's setting to true

### What is the Github issue?
#278 
### How should this be tested?
Open the control pabnel

### Screenshots (if appropriate)
<img width="189" alt="image" src="https://user-images.githubusercontent.com/55420821/159924488-4deb5827-3ed4-4709-9b6d-c87a0c74c525.png">

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
