### PR TITLE
Editor #418 Controller server: Reformat command structure into action and command array

### DIFF
--- a/controller-server/README.md
+++ b/controller-server/README.md
@@ -86,7 +86,7 @@ interface InfoType {
 }
 
 // Payload for UploadLed and UploadOf Command
-[
+{"Justin": //Or any other dancer name
 	{
 	  "start": 0, // ms
 	  "fade": true,
@@ -114,5 +114,5 @@ interface InfoType {
 	  }
 	},
 	...
-]
+}
 ```

--- a/controller-server/constants/index.ts
+++ b/controller-server/constants/index.ts
@@ -1,19 +1,24 @@
 // Command Type
-enum CommandType {
+enum ActionType {
   SYNC = "sync",
   UPLOAD_LED = "uploadLed",
   UPLOAD_OF = "uploadOf",
+  BOARDINFO = "boardInfo",
+  DISCONNECT = "disconnect",
+  // General Command
+  COMMAND = "command",
+}
+
+enum CommandSubType {
   LOAD = "load",
+  LIGTHCURRENTSTATUS = "lightCurrentStatus",
+  KICK = "kick",
   PLAY = "play",
   PAUSE = "pause",
   STOP = "stop",
-  LIGTHCURRENTSTATUS = "lightCurrentStatus",
-  KICK = "kick",
   SHUTDOWN = "shutDown",
   REBOOT = "reboot",
-  BOARDINFO = "boardInfo",
   TEST = "test",
-  DISCONNECT = "disconnect",
   RED = "red",
   BLUE = "blue",
   GREEN = "green",
@@ -22,4 +27,4 @@ enum CommandType {
   RESTARTCONTROLLER = "restartController",
 }
 
-export { CommandType };
+export { ActionType, CommandSubType };

--- a/controller-server/index.ts
+++ b/controller-server/index.ts
@@ -10,7 +10,7 @@ import { ClientType, MesC2S, MesS2C, InfoType, MesR2S } from "./types/index";
 import NtpServer from "./ntp/index";
 
 import { ClientAgent } from "./clientAgent";
-import { CommandType } from "./constants";
+import { ActionType } from "./constants";
 
 const app = express();
 const server = http.createServer(app);
@@ -31,7 +31,7 @@ wss.on("connection", (ws) => {
 
     // We defined that the first task for clients (dancer and editor) will be boardInfo
     // This can then let us split the logic between dancerClients and editorClients
-    if (command === CommandType.BOARDINFO) {
+    if (command === ActionType.BOARDINFO) {
 
       // fetch type, so ugly
       if ((<InfoType>payload).type) {
@@ -66,7 +66,7 @@ wss.on("connection", (ws) => {
             const dancerInfo = clientAgent.dancerClients.getClientsInfo();
 
             const res: MesS2C = {
-              command: CommandType.BOARDINFO,
+              command: ActionType.BOARDINFO,
               payload: {
                 success: true,
                 info: {
@@ -97,7 +97,7 @@ wss.on("connection", (ws) => {
             const dancerInfo = clientAgent.dancerClients.getClientsInfo();
 
             const res: MesS2C = {
-              command: CommandType.BOARDINFO,
+              command: ActionType.BOARDINFO,
               payload: {
                 success: true,
                 info: {
@@ -118,7 +118,7 @@ wss.on("connection", (ws) => {
       default: {
         console.error("Invalid type ", type, " on connection");
         const res: MesS2C = {
-          command: CommandType.BOARDINFO,
+          command: ActionType.BOARDINFO,
           payload: {
             success: false,
             info: "invalid type"

--- a/controller-server/types/index.ts
+++ b/controller-server/types/index.ts
@@ -1,6 +1,6 @@
 import ControlPanelSocket from "../websocket/controlPanelSocket";
 import DancerSocket from "../websocket/dancerSocket";
-import { CommandType } from "../constants/index";
+import { ActionType, CommandSubType } from "../constants/index";
 
 // General payload type
 // request only
@@ -47,13 +47,13 @@ interface SyncType {
 // Websocket message interface
 // Control Panel to Server
 interface MesC2S {
-  command: CommandType;
+  command: ActionType;
   selectedDancers: [string];
   payload: string | PlayTimeType | LightStatusType | InfoType; // Control panel frontend info
 }
 // Server to Control Panel
 interface MesS2C {
-  command: CommandType;
+  command: ActionType;
   payload: {
     from?: string; // DancerName type
     success: boolean;
@@ -63,12 +63,12 @@ interface MesS2C {
 // Server to RPi
 // In new protocol, the type of ControlType is strictly defined
 interface MesS2R {
-  command: CommandType;
-  payload?: string | PlayTimeType | LightStatusType | ControlType | LedType;
+  action: ActionType;
+  payload?: string | PlayTimeType | LightStatusType | ControlType | LedType | CommandSubType[];
 }
 // RPi to Server
 interface MesR2S {
-  command: CommandType;
+  command: ActionType;
   payload: {
     success: boolean;
     info: string | InfoType | SyncType; // RPi info
@@ -84,7 +84,7 @@ interface controlPanelClientDic {
 }
 
 export {
-  CommandType,
+  ActionType,
   TimeType,
   LightStatusType,
   PlayTimeType,

--- a/controller-server/websocket/controlPanelSocket.ts
+++ b/controller-server/websocket/controlPanelSocket.ts
@@ -1,5 +1,5 @@
 import { WebSocket } from "ws";
-import { CommandType } from "../constants";
+import { ActionType, CommandSubType } from "../constants";
 import { PlayTimeType, MesC2S, MesS2C } from "../types";
 import { ClientAgent } from "../clientAgent";
 import { v4 as uuidv4 } from "uuid";
@@ -19,9 +19,9 @@ class ControlPanelSocket {
     this.init(ws);
 
     this.methods = {
-      [CommandType.PAUSE]: this.pause,
-      [CommandType.PLAY]: this.play,
-      [CommandType.STOP]: this.stop,
+      [CommandSubType.PAUSE]: this.pause,
+      [CommandSubType.PLAY]: this.play,
+      [CommandSubType.STOP]: this.stop,
     };
   }
 

--- a/controller-server/websocket/dancerSocket.ts
+++ b/controller-server/websocket/dancerSocket.ts
@@ -1,4 +1,4 @@
-import { CommandType } from "../constants";
+import { ActionType, CommandSubType } from "../constants";
 import WebSocket from "ws";
 import {
   ClientType,
@@ -38,23 +38,23 @@ class DancerSocket {
     this.clientIP = ip;
 
     this.methods = {
-      [CommandType.SYNC]: this.sync,
-      [CommandType.KICK]: this.kick,
-      [CommandType.LIGTHCURRENTSTATUS]: this.lightCurrentStatus,
-      [CommandType.LOAD]: this.load,
-      [CommandType.PAUSE]: this.pause,
-      [CommandType.PLAY]: this.play,
-      [CommandType.REBOOT]: this.reboot,
-      [CommandType.SHUTDOWN]: this.shutDown,
-      [CommandType.STOP]: this.stop,
-      [CommandType.UPLOAD_OF]: this.uploadOf,
-      [CommandType.UPLOAD_LED]: this.uploadLED,
-      [CommandType.RED]: this.red,
-      [CommandType.BLUE]: this.blue,
-      [CommandType.GREEN]: this.green,
-      [CommandType.STMINIT]: this.stmInit,
-      [CommandType.DARKALL]: this.darkAll,
-      [CommandType.RESTARTCONTROLLER]: this.restartController,
+      [ActionType.SYNC]: this.sync,
+      [CommandSubType.KICK]: this.kick,
+      [CommandSubType.LIGTHCURRENTSTATUS]: this.lightCurrentStatus,
+      [CommandSubType.LOAD]: this.load,
+      [CommandSubType.PAUSE]: this.pause,
+      [CommandSubType.PLAY]: this.play,
+      [CommandSubType.REBOOT]: this.reboot,
+      [CommandSubType.SHUTDOWN]: this.shutDown,
+      [CommandSubType.STOP]: this.stop,
+      [ActionType.UPLOAD_OF]: this.uploadOf,
+      [ActionType.UPLOAD_LED]: this.uploadLED,
+      [CommandSubType.RED]: this.red,
+      [CommandSubType.BLUE]: this.blue,
+      [CommandSubType.GREEN]: this.green,
+      [CommandSubType.STMINIT]: this.stmInit,
+      [CommandSubType.DARKALL]: this.darkAll,
+      [CommandSubType.RESTARTCONTROLLER]: this.restartController,
     };
   }
 
@@ -96,7 +96,7 @@ class DancerSocket {
     this.ws.onclose = (message: any) => {
       console.log(`[Disconnect] dancer ${this.dancerName} disconnect!\n`);
       const disconnectResponse: MesS2C = {
-        command: CommandType.DISCONNECT,
+        command: ActionType.DISCONNECT,
         payload: {
           from: this.dancerName,
           success: false,
@@ -123,65 +123,105 @@ class DancerSocket {
   // };
   // Below are functions for manager to use
   sync = () => {
-    this.sendDataToRpiSocket({ command: CommandType.SYNC });
+    this.sendDataToRpiSocket({ action: ActionType.SYNC });
   };
   kick = () => {
-    this.sendDataToRpiSocket({ command: CommandType.KICK });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.KICK], 
+    });
   };
   lightCurrentStatus = (lightCurrentStatus: LightStatusType) => {
     this.sendDataToRpiSocket({
-      command: CommandType.LIGTHCURRENTSTATUS /* ,payload: light object*/,
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.LIGTHCURRENTSTATUS], /* ,payload: light object*/
     });
   };
   load = () => {
-    this.sendDataToRpiSocket({ command: CommandType.LOAD });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.LOAD],
+    });
   };
   pause = () => {
-    this.sendDataToRpiSocket({ command: CommandType.PAUSE });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.PAUSE], 
+    });
   };
   play = (time: PlayTimeType = { startTime: 0, delay: 0, sysTime: 0 }) => {
-    console.log(`[Debug] play: sysTime=${time.sysTime}`);
-    this.sendDataToRpiSocket({ command: CommandType.PLAY, payload: time });
+    console.log(`[Debug] play: sysTime=${time.sysTime} startTime=${time.startTime}`);
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.PLAY, (time.startTime)] // we sent start time in milliseconds 
+    });
   };
   reboot = () => {
-    this.sendDataToRpiSocket({ command: CommandType.REBOOT });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.REBOOT],
+    });
   };
   shutDown = () => {
-    this.sendDataToRpiSocket({ command: CommandType.SHUTDOWN });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.SHUTDOWN],
+    });
   };
   stop = () => {
-    this.sendDataToRpiSocket({ command: CommandType.STOP });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.STOP]
+    });
   };
 
   uploadOf = (data: ControlType) => {
     this.sendDataToRpiSocket({
-      command: CommandType.UPLOAD_OF /* payload: ControlType*/,
+      action: ActionType.UPLOAD_OF /* payload: ControlType*/,
       payload: data[this.dancerName],
     });
   };
   uploadLED = (data: ControlType) => {
     this.sendDataToRpiSocket({
-      command: CommandType.UPLOAD_LED /* payload: ControlType*/,
+      action: ActionType.UPLOAD_LED /* payload: ControlType*/,
       payload: data[this.dancerName],
     });
   };
   red = () => {
-    this.sendDataToRpiSocket({ command: CommandType.RED });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.RED],
+    });
   };
   blue = () => {
-    this.sendDataToRpiSocket({ command: CommandType.BLUE });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.BLUE]
+    });
   };
   green = () => {
-    this.sendDataToRpiSocket({ command: CommandType.GREEN });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.GREEN]
+    });
   };
   stmInit = () => {
-    this.sendDataToRpiSocket({ command: CommandType.STMINIT });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.STMINIT]
+    });
   };
   darkAll = () => {
-    this.sendDataToRpiSocket({ command: CommandType.DARKALL });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.DARKALL]
+    });
   };
   restartController = () => {
-    this.sendDataToRpiSocket({ command: CommandType.RESTARTCONTROLLER });
+    this.sendDataToRpiSocket({ 
+      action: ActionType.COMMAND,
+      payload: [CommandSubType.RESTARTCONTROLLER]
+    });
   };
 }
 

--- a/controller-server/websocket/testControlPanel1.js
+++ b/controller-server/websocket/testControlPanel1.js
@@ -14,7 +14,7 @@ socket.addEventListener("open", (evnt)  => {
     socket.send(JSON.stringify({
         command: "uploadOf",
         selectedDancers: ["Justin"],
-        payload: [{
+        payload: {"Justin" : {
             "start": 0, // ms
             "fade": true,
             "status": {
@@ -39,27 +39,35 @@ socket.addEventListener("open", (evnt)  => {
               "Glove_L": [255, 255, 255, 10],
               "Glove_R": [255, 255, 255, 10]
             }
-          }]
+          }}
 
         // uploadLED = (data: LedType) => {
         //      this.sendDataToRpiSocket({
-        //           command: CommandType.UPLOAD_LED /* payload: ControlType*/,
+        //           command: ActionType.UPLOAD_LED /* payload: ControlType*/,
         //           payload: data[this.dancerName],
         //         });
         //     };
     }));
 
-    // socket.send(JSON.stringify({
-    //     command: "stop",
-    //     selectedDancers: ["Justin"],
+    socket.send(JSON.stringify({
+        command: "stop",
+        selectedDancers: ["Justin"],
 
-    //     // play command:
-    //     // payload: {
-    //     //     startTime: 0, delay: 0, sysTime: 0 
-    //     // }
-    // }));
-    
+        // play command:
+        // payload: {
+        //     startTime: 0, delay: 0, sysTime: 0 
+        // }
+    }));
 
+    socket.send(JSON.stringify({
+        command: "play",
+        selectedDancers: ["Justin"],
+
+        // play command:
+        payload: {
+            startTime: 20, delay: 0, sysTime: 0 
+        }
+    }));
 
 });
 


### PR DESCRIPTION
… and command array

### What is this PR for?
* Change structure of payload when command time is "play", "pause", "stop", etc. (All commands other than upload and sync)
* Original structure
{
    command: "play",
    payload:  timeType
}

* New structure
{
    action: "command",
    payload: ["play", timeType]
}

### What type of PR is it?
Bug Fix

### Todos

* [X] Differentiate action types (ex: upload / sync) and command subtypes (ex: play, stop) in typescript
* [X]  Change payload structure for command subtypes into an array

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/112947088/223037409-3baa547b-c567-4ab6-8b0f-b985682ce0ac.png)

### Please help merge this pull request into the main branch
