### PR TITLE
Editor-#426 Controller server: Add Refresh command & Connect to backend API

### DIFF
--- a/controller-server/api/axios.ts
+++ b/controller-server/api/axios.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const instance = axios.create({
+  baseURL: "/api/editor-server",
+});
+
+export { instance };

--- a/controller-server/api/getDancerFiberData.ts
+++ b/controller-server/api/getDancerFiberData.ts
@@ -1,0 +1,18 @@
+import { instance } from  "./axios"
+
+const getDancerFiberData = async (dancerName: string) => {
+    try {
+      const res = await instance.get("/getDancerFiberData", {
+        params: {dancer: dancerName}
+      });
+
+      return {
+        token: res.data.token,
+        success: res.status === 200,
+      };
+    } catch (error) {
+      return {
+        success: false,
+      };
+    }
+  }

--- a/controller-server/api/getDancerFiberData.ts
+++ b/controller-server/api/getDancerFiberData.ts
@@ -2,17 +2,18 @@ import { instance } from  "./axios"
 
 const getDancerFiberData = async (dancerName: string) => {
     try {
-      const res = await instance.get("/getDancerFiberData", {
-        params: {dancer: dancerName}
-      });
-
+      const res = await instance.get(`/getDancerFiberData?dancer=${dancerName}`)
+      if(!res.data) console.log(`[API GET ERROR] ${dancerName} cannot be found in editor server /getDancerFiberData API`)
       return {
-        token: res.data.token,
-        success: res.status === 200,
-      };
+        success: !(!res.data),
+        data: res.data,
+      }
     } catch (error) {
       return {
         success: false,
+        message: error,
       };
     }
   }
+
+  export { getDancerFiberData }

--- a/controller-server/api/getDancerLEDData.ts
+++ b/controller-server/api/getDancerLEDData.ts
@@ -1,0 +1,19 @@
+import { instance } from  "./axios"
+
+const getDancerLEDData = async (dancerName: string) => {
+    try {
+        const res = await instance.get(`/getDancerLEDData?dancer=${dancerName}`)
+        if(!res.data) console.log(`[API GET ERROR] ${dancerName} cannot be found in editor server /getDancerLEDData API`)
+        return {
+            success: !(!res.data),
+            data: res.data,
+          }
+        } catch (error) {
+          return {
+            success: false,
+            message: error,
+          };
+        }
+  }
+
+  export { getDancerLEDData }

--- a/controller-server/constants/index.ts
+++ b/controller-server/constants/index.ts
@@ -3,6 +3,7 @@ enum ActionType {
   SYNC = "sync",
   UPLOAD_LED = "uploadLed",
   UPLOAD_OF = "uploadOf",
+  REFRESH = "refresh",
   UPLOAD = "upload",
   BOARDINFO = "boardInfo",
   DISCONNECT = "disconnect",

--- a/controller-server/constants/macList.ts
+++ b/controller-server/constants/macList.ts
@@ -4,7 +4,7 @@
 
 // Test ver.
 const MAC_LIST: { [key: string]: string[] }= {
-    "1C:4D:70:0A:60:40": ["Ray", "127.0.0", "light-dance"]
+    "1C:4D:70:0A:60:40": ["1_hank", "127.0.0", "light-dance"]
 }
 
 

--- a/controller-server/database/dancerControlJson.ts
+++ b/controller-server/database/dancerControlJson.ts
@@ -16,7 +16,7 @@ interface ControlJsonType {
 // The following is only a test db, not the real version used in 2023 EE-Night
 // ControlJsonDB is fixed when controller server is running, NO client (e.g. RPi, Control Panel) would be able to modify ControlJsonDB
 const ControlJsonDB: {[key: string]: ControlJsonType} = {
-    "Ray": { // Dancer name is used as key for the dictionary
+    "1_hank": { // Dancer name is used as key for the dictionary
         "fps": 30,
         "OFPARTS": {
             "of1": 0,

--- a/controller-server/package.json
+++ b/controller-server/package.json
@@ -6,6 +6,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "@types/websocket": "^1.0.5",
+    "axios": "^1.3.4",
     "body-parser": "^1.19.1",
     "express": "^4.17.2",
     "ts-node": "^10.5.0",

--- a/controller-server/pnpm-lock.yaml
+++ b/controller-server/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@types/ws': ^8.5.1
   '@typescript-eslint/eslint-plugin': ^5.48.1
   '@typescript-eslint/parser': ^5.48.1
+  axios: ^1.3.4
   body-parser: ^1.19.1
   eslint: ^8.31.0
   express: ^4.17.2
@@ -18,6 +19,7 @@ specifiers:
 
 dependencies:
   '@types/websocket': 1.0.5
+  axios: 1.3.4
   body-parser: 1.20.1
   express: 4.18.2
   ts-node: 10.9.1_typescript@4.9.4
@@ -415,6 +417,20 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
+  /axios/1.3.4:
+    resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -509,6 +525,13 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -585,6 +608,11 @@ packages:
   /deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
+
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
 
   /depd/2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -876,6 +904,25 @@ packages:
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
+
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1317,6 +1364,10 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+    dev: false
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: false
 
   /pstree.remy/1.1.8:

--- a/controller-server/websocket/testControlPanel1.js
+++ b/controller-server/websocket/testControlPanel1.js
@@ -10,11 +10,15 @@ socket.addEventListener("open", (evnt)  => {
             type:  "controlPanel",
         }
     }));
+    socket.send(JSON.stringify({
+        command: "refresh",
+        selectedDancers: ["1_hank"],
+    }));
 
     socket.send(JSON.stringify({
         command: "uploadOf",
-        selectedDancers: ["Ray"],
-        payload: {"Ray" :  [ 
+        selectedDancers: ["1_hank"],
+        payload: {"1_hank" :  [ 
             {
             "start": 0,
             "fade": true,
@@ -79,7 +83,7 @@ socket.addEventListener("open", (evnt)  => {
     }));
 
     const UPLOAD_LED_JSON = {
-        "Ray": {
+        "1_hank": {
             "led1": [
             {
                 "start": 150,
@@ -171,13 +175,13 @@ socket.addEventListener("open", (evnt)  => {
 
     socket.send(JSON.stringify({
         command: "uploadLed",
-        selectedDancers: ["Ray"],
+        selectedDancers: ["1_hank"],
         payload: UPLOAD_LED_JSON
     }))
 
     // socket.send(JSON.stringify({
     //     command: "stop",
-    //     selectedDancers: ["Ray"],
+    //     selectedDancers: ["1_hank"],
 
     //     // play command:
     //     // payload: {
@@ -187,7 +191,7 @@ socket.addEventListener("open", (evnt)  => {
 
     // socket.send(JSON.stringify({
     //     command: "play",
-    //     selectedDancers: ["Ray"],
+    //     selectedDancers: ["1_hank"],
 
     //     // play command:
     //     payload: {

--- a/controller-server/websocket/testRPi1.js
+++ b/controller-server/websocket/testRPi1.js
@@ -5,13 +5,13 @@ const socket = new WebSocket("ws://localhost:8082");
 socket.addEventListener("open", evnt => {
     console.log("Client RPi 1 websocket open on port ws://localhost:8082");
     socket.send(JSON.stringify({
-        command: "boardInfo",
-        payload: {
-            type:  "RPi",
-            info: {
-                dancerName: "Justin",
-                ip: "127.0.0",
-                hostName: "light-dance",
+        "command": "boardInfo",
+        "status": 0,
+        "payload": 
+        {
+            "type":  "RPi",
+            "info": {
+                "macaddr" : "1C:4D:70:0A:60:40",
             }
         }
     }));


### PR DESCRIPTION
### Ready for Merging!
### What is this PR for?
* Replace uploadOf and uploadLed command from command center (control panel) into the REFRESH command
* Instead of fetching OF data and LED data from the payload of uploadOf and uploadLed command, fetch from 2 editor-server APIs.
* Send response similar to "BOARDINFO" to RPi when REFRESH command is called by command center (control panel).

### What type of PR is it?
Improvement

### Todos

* [X] Add refresh command into command list
* [X] Connect to editor-server APIs to fetch Of and Led Data
* [X] Send [control.json, Of.json, Led.json] payload to RPi when REFRESH command is callled

### Screenshots (if appropriate)
