### PR TITLE
EDITOR-#473 Rewrite UploadData

### DIFF
--- a/editor-server/Cargo.lock
+++ b/editor-server/Cargo.lock
@@ -1077,12 +1077,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
-<<<<<<< HEAD
  "http",
- "itertools 0.12.0",
-=======
  "indicatif",
->>>>>>> temp
+ "itertools 0.12.0",
  "once_cell",
  "redis",
  "serde",

--- a/editor-server/Cargo.lock
+++ b/editor-server/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -683,7 +683,7 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -720,6 +720,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97faeec45f49581c458f8bf81992c5e3ec17d82cda99f59d3cea14eff62698d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1064,8 +1077,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+<<<<<<< HEAD
  "http",
  "itertools 0.12.0",
+=======
+ "indicatif",
+>>>>>>> temp
  "once_cell",
  "redis",
  "serde",
@@ -1087,6 +1104,12 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1136,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1147,7 +1170,7 @@ checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
  "cfg-if",
  "home",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1623,7 +1646,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1776,6 +1799,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,7 +1849,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2221,7 +2257,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2480,6 +2516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,7 +2666,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2799,6 +2841,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "ppv-lite86"
@@ -3431,7 +3479,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3458,7 +3506,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3710,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4114,7 +4162,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4206,7 +4254,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.4",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4508,6 +4556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4741,7 +4795,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4750,7 +4804,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -4759,13 +4822,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -4775,10 +4853,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4787,10 +4877,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4799,16 +4901,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
@@ -4826,7 +4946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/editor-server/Cargo.toml
+++ b/editor-server/Cargo.toml
@@ -21,6 +21,7 @@ futures-core = "0.3.28"
 futures-util = "0.3.28"
 http = "0.2.7"
 itertools = "0.12.0"
+indicatif = { version = "*" }
 once_cell = "1.18.0"
 redis = { version = "0.23.3", features = ["tokio-comp"] }
 serde = "1.0.188"

--- a/editor-server/src/routes/api/mod.rs
+++ b/editor-server/src/routes/api/mod.rs
@@ -32,4 +32,5 @@ pub fn build_api_routes() -> Router {
             "/getDancerLEDData",
             get(get_dancer_led_data::get_dancer_led_data),
         )
+        .route("/uploadData", post(upload_data::upload_data))
 }

--- a/editor-server/src/routes/api/upload_data.rs
+++ b/editor-server/src/routes/api/upload_data.rs
@@ -105,11 +105,8 @@ pub async fn upload_data(
             ))
         };
         
-        // More manual checks on data format?
+        let app_state = global::clients::get();
 
-        let app_state = global::clients::get()
-            .into_result()?
-            .clone();
         let mysql = app_state.mysql_pool();
 
         // Cleaner way to do this?
@@ -343,7 +340,13 @@ pub async fn upload_data(
                         DancerPartType::FIBER => "COLOR",
                     };
                     let color_id = color_dict.get(&part_control_data.0);
-                    let effect_id = led_dict[part_name].get(&part_control_data.0);
+                    let effect_id = match led_dict.get(part_name) {
+                        Some(obj) => match obj.get(&part_control_data.0) {
+                            Some(i) => Some(i),
+                            None => None,
+                        }, 
+                        None => None,
+                    };
                     let alpha = part_control_data.1;
 
                     let _ = sqlx::query!(
@@ -370,7 +373,7 @@ pub async fn upload_data(
         // println!("{:?}", data_obj.color);
         // println!("{:?}", data_obj.dancer);
         // println!("{:?}", data_obj.led_effects);
-
+        println!("Upload Finish!");
         Ok((StatusCode::OK, Json(UploadDataResponse("Data Uploaded Successfully!".to_string()))))
     } else {
         Err((

--- a/editor-server/src/routes/api/upload_data.rs
+++ b/editor-server/src/routes/api/upload_data.rs
@@ -1,1 +1,383 @@
+use crate::global;
 
+use axum::{http::StatusCode, response::Json, extract::Multipart};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use indicatif::ProgressBar;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ControlData {
+    start: i32,
+    fade: bool, 
+    status: Vec<Vec<(String, i32)>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PositionData {
+    start: i32, 
+    pos: Vec<[i32; 3]>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LEDFrame {
+    #[serde(rename = "LEDs")]
+    leds: Vec<(String, i32)>,
+    start: i32,
+    fade: bool,
+}
+#[derive(Debug, Deserialize, Serialize)]
+struct LEDPart {
+    repeat: i32, 
+    frames: Vec<LEDFrame>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+enum DancerPartType {
+    LED,
+    FIBER,
+}
+#[derive(Debug, Deserialize, Serialize)]
+struct DancerPart {
+    name: String,
+    #[serde(rename = "type")]
+    part_type: DancerPartType,
+    length: Option<i32>,
+}
+#[derive(Debug, Deserialize, Serialize)]
+struct Dancer {
+    name: String, 
+    parts: Vec<DancerPart>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct DataObj {
+    position: HashMap<String, PositionData>,
+    control: HashMap<String, ControlData>,
+    dancer: Vec<Dancer>,
+    color: HashMap<String, [i32; 3]>,
+    #[serde(rename = "LEDEffects")]
+    led_effects: HashMap<String, HashMap<String, LEDPart>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UploadDataResponse(String);
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UploadDataFailedResponse {
+    err: String,
+}
+
+trait IntoResult<T, E> {
+    fn into_result(self) -> Result<T, E>;
+}
+
+impl<R, E> IntoResult<R, (StatusCode, Json<UploadDataFailedResponse>)> for Result<R, E>
+where
+    E: std::string::ToString,
+{
+    fn into_result(self) -> Result<R, (StatusCode, Json<UploadDataFailedResponse>)> {
+        match self {
+            Ok(ok) => Ok(ok),
+            Err(err) => Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(UploadDataFailedResponse {
+                    err: err.to_string(),
+                })
+            ))
+        }
+    }
+}
+
+pub async fn upload_data(
+    mut files: Multipart
+) -> Result<(StatusCode, Json<UploadDataResponse>), (StatusCode, Json<UploadDataFailedResponse>)> {
+    // read request
+    if let Some(field) = files.next_field().await.into_result()? {
+        let raw_data = field.bytes().await.into_result()?;
+        // parse json & check types
+        let data_obj: DataObj = match serde_json::from_slice(&raw_data) {
+            Ok(data_obj) => data_obj,
+            Err(e) => return Err((
+                StatusCode::BAD_REQUEST,
+                Json(UploadDataFailedResponse {
+                    err: format!("JSON was not well formatted: {e}"),
+                }),
+            ))
+        };
+        
+        // More manual checks on data format?
+
+        let app_state = global::clients::get()
+            .into_result()?
+            .clone();
+        let mysql = app_state.mysql_pool();
+
+        // Cleaner way to do this?
+        let _ = sqlx::query!(r#"DELETE FROM Color"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM PositionData"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM ControlData"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM Part"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM Dancer"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM PositionFrame"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM ControlFrame"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM LEDEffect"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM LEDEffectState"#,).execute(mysql).await;
+        let _ = sqlx::query!(r#"DELETE FROM EffectListData"#,).execute(mysql).await;
+        println!("DB cleared");
+        
+        // HashMap<ColorName, ColorID>
+        let mut color_dict: HashMap<&String, i32> = HashMap::new();
+        let color_progress = ProgressBar::new(data_obj.color.len().try_into().unwrap_or_default());
+        println!("Create Colors...");
+        for (color_key, color_code) in &data_obj.color {
+            let color_id = sqlx::query!(
+                r#"
+                    INSERT INTO Color (name, r, g, b)
+                    VALUES (?, ?, ?, ?);
+                "#,
+                color_key,
+                color_code[0],
+                color_code[1],
+                color_code[2],
+            )
+            .execute(mysql)
+            .await
+            .into_result()?
+            .last_insert_id() as i32;
+
+            color_dict.insert(color_key, color_id);
+            color_progress.inc(1);
+        }
+        color_progress.finish();
+
+        // HashMap<LEDPartName, HashMap<EffectName, EffectID>>
+        let mut led_dict: HashMap<&String, HashMap<&String, i32>> = HashMap::new();
+        let led_progress = ProgressBar::new(data_obj.led_effects.len().try_into().unwrap_or_default());
+        println!("Create LED Effects...");
+        for (part_name, effects) in &data_obj.led_effects {
+            let mut effect_dict: HashMap<&String, i32> = HashMap::new();
+            for (effect_name, effect_data) in effects {
+                let effect_id = sqlx::query!(
+                    r#"
+                        INSERT INTO LEDEffect (name, part_name)
+                        VALUES (?, ?);
+                    "#,
+                    effect_name,
+                    part_name,
+                )
+                .execute(mysql)
+                .await
+                .into_result()?
+                .last_insert_id() as i32;
+
+                effect_dict.insert(effect_name, effect_id);
+
+                // Only one frame?
+                for (index, (color, alpha)) in effect_data.frames[0].leds.iter().enumerate() {
+                    // What to do if color not found?
+                    let color_id = match color_dict.get(color) {
+                        Some(i) => i,
+                        None => return Err((
+                            StatusCode::BAD_REQUEST,
+                            Json(UploadDataFailedResponse {
+                                err: format!("Error: Unknown Color Name {color} in LEDEffects/{part_name}/{effect_name} at frame 0, index {index}."),
+                            }),
+                        ))
+                    };
+                    let _ = sqlx::query!(
+                        r#"
+                            INSERT INTO LEDEffectState (effect_id, position, color_id, alpha)
+                            VALUES (?, ?, ?, ?);
+                        "#,
+                        effect_id, 
+                        index as i32, 
+                        color_id,
+                        alpha,
+                    )
+                    .execute(mysql)
+                    .await
+                    .into_result()?;
+                }
+            }
+            led_dict.insert(part_name, effect_dict);
+            led_progress.inc(1);
+        }
+        led_progress.finish();
+
+        // What's the point of "partsList" anyways...
+        // HashMap<DancerName, (DancerID, HashMap<PartName, (PartID, PartType)>)>
+        let mut all_dancer: HashMap<&String, (i32, HashMap<&String, (i32, &DancerPartType)>)> = HashMap::new();
+        let dancer_progress = ProgressBar::new(data_obj.dancer.len().try_into().unwrap_or_default());
+        println!("Create Dancers...");
+        for dancer in &data_obj.dancer {
+            let dancer_id = sqlx::query!(
+                r#"
+                    INSERT INTO Dancer (name)
+                    VALUES (?);
+                "#,
+                dancer.name,
+            )
+            .execute(mysql)
+            .await
+            .into_result()?
+            .last_insert_id() as i32;
+
+            let mut part_dict: HashMap<&String, (i32, &DancerPartType)> = HashMap::new();
+            for part in &dancer.parts {
+                let type_string = match &part.part_type {
+                    DancerPartType::LED => "LED",
+                    DancerPartType::FIBER => "FIBER",
+                };
+                let part_id = sqlx::query!(
+                    r#"
+                        INSERT INTO Part (dancer_id, name, type, length)
+                        VALUES (?, ?, ?, ?);
+                    "#,
+                    dancer_id,
+                    part.name,
+                    type_string,
+                    part.length,
+                )
+                .execute(mysql)
+                .await
+                .into_result()?
+                .last_insert_id() as i32;
+
+                part_dict.insert(&part.name, (part_id, &part.part_type));
+            }
+            all_dancer.insert(&dancer.name, (dancer_id, part_dict));
+            dancer_progress.inc(1);
+        }
+        dancer_progress.finish();
+
+        let position_progress = ProgressBar::new(data_obj.position.len().try_into().unwrap_or_default());
+        println!("Create Position Data...");
+        for (_, frame_obj) in &data_obj.position {
+            if frame_obj.pos.len() != data_obj.dancer.len() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(UploadDataFailedResponse {
+                        err: format!("Error: Position frame starting at {} has invalid number of dancers. Found {}, Expected {}.",
+                         frame_obj.start, frame_obj.pos.len(), data_obj.dancer.len()),
+                    }),
+                ));
+            }
+            let frame_id = sqlx::query!(
+                r#"
+                    INSERT INTO PositionFrame (start)
+                    VALUES (?);
+                "#,
+                frame_obj.start,
+            )
+            .execute(mysql)
+            .await
+            .into_result()?
+            .last_insert_id() as i32;
+
+            // How do I implement "withConcurrency" here?
+            for (index, dancer_pos_data) in frame_obj.pos.iter().enumerate() {
+                let dancer_id = all_dancer[&data_obj.dancer[index].name].0;
+                let _ = sqlx::query!(
+                    r#"
+                        INSERT INTO PositionData (dancer_id, frame_id, x, y, z)
+                        VALUES (?, ?, ?, ?, ?);
+                    "#,
+                    dancer_id, 
+                    frame_id,
+                    dancer_pos_data[0],
+                    dancer_pos_data[1],
+                    dancer_pos_data[2],
+                )
+                .execute(mysql)
+                .await
+                .into_result()?;
+            }
+            position_progress.inc(1);
+        }
+        position_progress.finish();
+
+        let control_progress = ProgressBar::new(data_obj.control.len().try_into().unwrap_or_default());
+        println!("Create Control Data...");
+        for (_, frame_obj) in &data_obj.control {
+            if frame_obj.status.len() != data_obj.dancer.len() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(UploadDataFailedResponse {
+                        err: format!("Error: Control frame starting at {} has invalid number of dancers. Found {}, Expected {}.",
+                         frame_obj.start, frame_obj.status.len(), data_obj.dancer.len()),
+                    }),
+                ));
+            }
+            let frame_id = sqlx::query!(
+                r#"
+                    INSERT INTO ControlFrame (start, fade)
+                    VALUES (?, ?);
+                "#,
+                frame_obj.start,
+                frame_obj.fade,
+            )
+            .execute(mysql)
+            .await
+            .into_result()?
+            .last_insert_id() as i32;
+
+            for (i, dancer_control_data) in frame_obj.status.iter().enumerate() {
+                if frame_obj.status[i].len() != data_obj.dancer[i].parts.len() {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        Json(UploadDataFailedResponse {
+                            err: format!("Error: Control frame starting at {}, dancer index {} has invalid number of parts. Found {}, Expected {}.",
+                             frame_obj.start, i, frame_obj.status[i].len(), data_obj.dancer[i].parts.len()),
+                        }),
+                    ));
+                };
+                let dancer_name = &data_obj.dancer[i].name;
+                let real_dancer = &all_dancer[dancer_name];
+
+                for (j, part_control_data) in dancer_control_data.iter().enumerate() {
+                    let part_name = &data_obj.dancer[i].parts[j].name;
+                    let real_part = &real_dancer.1[part_name];
+                    // This is apparently wrong currently
+                    let type_string = match &real_part.1 {
+                        DancerPartType::LED => "EFFECT",
+                        DancerPartType::FIBER => "COLOR",
+                    };
+                    let color_id = color_dict.get(&part_control_data.0);
+                    let effect_id = led_dict[part_name].get(&part_control_data.0);
+                    let alpha = part_control_data.1;
+
+                    let _ = sqlx::query!(
+                        r#"
+                            INSERT INTO ControlData (part_id, frame_id, type, color_id, effect_id, alpha)
+                            VALUES (?, ?, ?, ?, ?, ?);
+                        "#,
+                        real_part.0,
+                        frame_id,
+                        type_string,
+                        color_id,
+                        effect_id,
+                        alpha,
+                    )
+                    .execute(mysql)
+                    .await
+                    .into_result()?;
+                }
+            }
+            control_progress.inc(1);
+        }
+        control_progress.finish();
+
+        // println!("{:?}", data_obj.color);
+        // println!("{:?}", data_obj.dancer);
+        // println!("{:?}", data_obj.led_effects);
+
+        Ok((StatusCode::OK, Json(UploadDataResponse("Data Uploaded Successfully!".to_string()))))
+    } else {
+        Err((
+            StatusCode::BAD_REQUEST,
+            Json(UploadDataFailedResponse {
+                err: "No File!".to_string()
+            }), 
+        ))
+    }
+}

--- a/editor-server/src/routes/api/upload_data.rs
+++ b/editor-server/src/routes/api/upload_data.rs
@@ -171,9 +171,7 @@ pub async fn upload_data(
 
                 effect_dict.insert(effect_name, effect_id);
 
-                // Only one frame?
                 for (index, (color, alpha)) in effect_data.frames[0].leds.iter().enumerate() {
-                    // What to do if color not found?
                     let color_id = match color_dict.get(color) {
                         Some(i) => i,
                         None => {
@@ -205,7 +203,6 @@ pub async fn upload_data(
         }
         led_progress.finish();
 
-        // What's the point of "partsList" anyways...
         // HashMap<DancerName, (DancerID, HashMap<PartName, (PartID, PartType)>)>
         let mut all_dancer: HashMap<&String, (i32, HashMap<&String, (i32, &DancerPartType)>)> = HashMap::new();
         let dancer_progress = ProgressBar::new(data_obj.dancer.len().try_into().unwrap_or_default());
@@ -275,7 +272,6 @@ pub async fn upload_data(
             .into_result()?
             .last_insert_id() as i32;
 
-            // How do I implement "withConcurrency" here?
             for (index, dancer_pos_data) in frame_obj.pos.iter().enumerate() {
                 let dancer_id = all_dancer[&data_obj.dancer[index].name].0;
                 let _ = sqlx::query!(
@@ -352,25 +348,25 @@ pub async fn upload_data(
                         None => None,
                     };
 
-                    if color_id == None && type_string == "COLOR" {
-                        return Err((
-                            StatusCode::BAD_REQUEST,
-                            Json(UploadDataFailedResponse {
-                                err: format!("Error: Control frame starting at {}, dancer index {}, part index {} has unknown color {}.",
-                                 frame_obj.start, i, j, &part_control_data.0),
-                            }),
-                        ));
-                    };
+                    // if color_id == None && type_string == "COLOR" {
+                    //     return Err((
+                    //         StatusCode::BAD_REQUEST,
+                    //         Json(UploadDataFailedResponse {
+                    //             err: format!("Error: Control frame starting at {}, dancer index {}, part index {} has unknown color {}.",
+                    //              frame_obj.start, i, j, &part_control_data.0),
+                    //         }),
+                    //     ));
+                    // };
 
-                    if effect_id == None && type_string == "EFFECT" {
-                        return Err((
-                            StatusCode::BAD_REQUEST,
-                            Json(UploadDataFailedResponse {
-                                err: format!("Error: Control frame starting at {}, dancer index {}, part index {} has unknown LED effect {}.",
-                                 frame_obj.start, i, j, &part_control_data.0),
-                            }),
-                        ));
-                    };
+                    // if effect_id == None && type_string == "EFFECT" {
+                    //     return Err((
+                    //         StatusCode::BAD_REQUEST,
+                    //         Json(UploadDataFailedResponse {
+                    //             err: format!("Error: Control frame starting at {}, dancer index {}, part index {} has unknown LED effect {}.",
+                    //              frame_obj.start, i, j, &part_control_data.0),
+                    //         }),
+                    //     ));
+                    // };
 
                     let alpha = part_control_data.1;
 

--- a/editor-server/src/utils/data.rs
+++ b/editor-server/src/utils/data.rs
@@ -95,7 +95,7 @@ pub async fn init_redis_control(
 
                         match part_control.part_type {
                             PartType::LED => {
-                                PartControl(part_control.effect_id.unwrap(), part_control.alpha)
+                                PartControl(part_control.effect_id.unwrap_or(-1), part_control.alpha)
                             }
                             PartType::FIBER => {
                                 PartControl(part_control.color_id.unwrap(), part_control.alpha)
@@ -280,7 +280,7 @@ pub async fn update_redis_control(
                         .unwrap_or_else(|| panic!("ControlData {} not found", frame.id));
                     match part_control.part_type {
                         PartType::LED => {
-                            PartControl(part_control.effect_id.unwrap(), part_control.alpha)
+                            PartControl(part_control.effect_id.unwrap_or(-1), part_control.alpha)
                         }
                         PartType::FIBER => {
                             PartControl(part_control.color_id.unwrap(), part_control.alpha)

--- a/utils/initDB.js
+++ b/utils/initDB.js
@@ -8,7 +8,7 @@ const FormData = require("form-data");
 const filePath = process.argv[2];
 
 const instance = axios.create({
-  baseURL: "http://localhost:4000/",
+  baseURL: "http://localhost:4001/",
   // baseURL: "http://localhost:8080/",
   maxContentLength: Infinity,
   maxBodyLength: Infinity,


### PR DESCRIPTION
### What is this PR for?
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

### What type of PR is it?

Feature

### Todos

No

### What is the Github issue?

#473 

### How should this be tested?

cd Lightdance-Editor/utils
node initDB.js jsons/exportDataEmpty.json

然後 對 他不會動:tf:
因為在control/start=0裡面有某些LED part的effect是"" (空的) ，如果我直接把effect_id=null寫進DB，在後端重開之後就會crash (utils/data.rs第289行)
去年的做法是寫effect_id=-1，但是這樣在新的DB schema下會寫不進去 (relation會檢查id是不是合法的)
所以我目前是讓他直接噴error然後退出

如果把那個frame整個刪掉 目前是能夠成功執行(但我沒有很認真嘗試戳爛他)

還有就是目前還無法支援LED part但是type=COLOR的部分，是可以改成名字找到哪個就用哪個，但如果有一個color和一個led effect的name一模一樣時就會出事

### Screenshots (if appropriate)

### Questions

* Do the license files need updating? Yes/No
* Are there breaking changes for older versions? Yes/No
* Does this need new documentation? Yes/No
