### PR TITLE
temprorary fix to graphiql

### DIFF
--- a/editor-server/src/routes/graphql.rs
+++ b/editor-server/src/routes/graphql.rs
@@ -4,8 +4,8 @@ use crate::graphql::schema::AppSchema;
 use crate::graphql::subscriptor::websocket::GraphQLSubscription;
 use crate::server::extractors::Authentication;
 use crate::server::websocket::{ws_on_connect, ws_on_disconnect};
+use crate::utils::graphiql::GraphiQLBuilder;
 
-use async_graphql::http::GraphiQLSource;
 use async_graphql::{Request, Response};
 
 use axum::{
@@ -40,7 +40,8 @@ async fn graphql(
 
 async fn graphiql() -> impl IntoResponse {
     Html(
-        GraphiQLSource::build()
+        GraphiQLBuilder::build()
+            .version("2.0.9")
             .endpoint("/graphql")
             .subscription_endpoint("/graphql-websocket")
             .finish(),

--- a/editor-server/src/utils/graphiql.rs
+++ b/editor-server/src/utils/graphiql.rs
@@ -1,0 +1,102 @@
+#[derive(Default)]
+pub struct GraphiQLBuilder<'a> {
+    version: &'a str,
+    endpoint: &'a str,
+    subscription_endpoint: &'a str,
+}
+
+impl<'a> GraphiQLBuilder<'a> {
+    pub fn build() -> GraphiQLBuilder<'a> {
+        Default::default()
+    }
+
+    pub fn version(self, version: &'a str) -> GraphiQLBuilder<'a> {
+        GraphiQLBuilder { version, ..self }
+    }
+
+    pub fn endpoint(self, endpoint: &'a str) -> GraphiQLBuilder<'a> {
+        GraphiQLBuilder { endpoint, ..self }
+    }
+
+    pub fn subscription_endpoint(self, subscription_endpoint: &'a str) -> GraphiQLBuilder {
+        GraphiQLBuilder {
+            subscription_endpoint,
+            ..self
+        }
+    }
+
+    pub fn finish(self) -> String {
+        format!(
+            r#"
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="robots" content="noindex">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <meta name="referrer" content="origin">
+
+            <title>GraphiQL IDE</title>
+
+            <style>
+              body {{
+                height: 100%;
+                margin: 0;
+                width: 100%;
+                overflow: hidden;
+              }}
+
+              #graphiql {{
+                height: 100vh;
+              }}
+            </style>
+            <script
+              crossorigin
+              src="https://unpkg.com/react@17/umd/react.development.js"
+            ></script>
+            <script
+              crossorigin
+              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+            ></script>
+            <link rel="icon" href="https://graphql.org/favicon.ico">
+            <link rel="stylesheet" href="https://unpkg.com/graphiql@{}/graphiql.min.css" />
+          </head>
+
+          <body>
+            <div id="graphiql">Loading...</div>
+            <script
+              src="https://unpkg.com/graphiql@{}/graphiql.min.js"
+              type="application/javascript"
+            ></script>
+            <script>
+              customFetch = (url, opts = {{}}) => {{
+                return fetch(url, {{...opts, credentials: 'same-origin'}})
+              }}
+
+              createUrl = (endpoint, subscription = false) => {{
+                const url = new URL(endpoint, window.location.origin);
+                if (subscription) {{
+                  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+                }}
+                return url.toString();
+              }}
+
+              ReactDOM.render(
+                React.createElement(GraphiQL, {{
+                  fetcher: GraphiQL.createFetcher({{
+                    url: createUrl('{}'),
+                    fetch: customFetch,
+                    subscriptionUrl: createUrl('{}', true),
+                  }}),
+                  defaultEditorToolsVisibility: true,
+                }}),
+                document.getElementById("graphiql")
+              );
+            </script>
+          </body>
+        </html>
+        "#,
+            self.version, self.version, self.endpoint, self.subscription_endpoint,
+        )
+    }
+}

--- a/editor-server/src/utils/graphiql.rs
+++ b/editor-server/src/utils/graphiql.rs
@@ -18,7 +18,7 @@ impl<'a> GraphiQLBuilder<'a> {
         GraphiQLBuilder { endpoint, ..self }
     }
 
-    pub fn subscription_endpoint(self, subscription_endpoint: &'a str) -> GraphiQLBuilder {
+    pub fn subscription_endpoint(self, subscription_endpoint: &'a str) -> GraphiQLBuilder<'a> {
         GraphiQLBuilder {
             subscription_endpoint,
             ..self

--- a/editor-server/src/utils/mod.rs
+++ b/editor-server/src/utils/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod authentication;
 pub mod data;
+pub mod graphiql;
 pub mod revision;
 pub mod vector;


### PR DESCRIPTION
### What is this PR for?
`async_graphql::http::GraphiQLSource` doesn't seem to be working due to version problems. This temporary fixes the problem by serving GraphiQL directly.

### What type of PR is it?

[Bug Fix]

### Todos
- [ ]  Find a way to resolve the "Decorated type deeper than introspection query." error.

### How should this be tested?
graphiql should now work

### Questions

* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
